### PR TITLE
Expand AssertListContains to match workshop example

### DIFF
--- a/src/test/java/com/github/timtebeek/betterassertions/junit5/AssertListContains.java
+++ b/src/test/java/com/github/timtebeek/betterassertions/junit5/AssertListContains.java
@@ -12,13 +12,17 @@ class AssertListContains {
     List<String> list = List.of("a", "b", "c");
 
     @Test
-    void assertListSize() {
+    void assertMultipleElements() {
+        assertTrue(list.contains("a"));
         assertTrue(list.contains("b"));
+        assertTrue(list.contains("c"));
     }
 
     @Disabled
     @Test
-    void assertListSizeFails() {
+    void assertMultipleElementsFails() {
+        assertTrue(list.contains("a"));
         assertTrue(list.contains("E"));
+        assertTrue(list.contains("c"));
     }
 }


### PR DESCRIPTION
## Summary

- Expanded `AssertListContains` to use three `assertTrue(list.contains(...))` calls instead of one, aligning with the workshop's "combine checks for multiple elements" example from openrewrite/break-your-testing-habits#94.
- Renamed test methods from `assertListSize` to `assertMultipleElements` to better reflect what they demonstrate.
- The failure case now shows that multiple `assertTrue` calls stop at the first failure, hiding that other elements pass — motivating the switch to `assertThat(list).contains("a", "b", "c")`.

## Test plan
- [x] `mvn test` passes